### PR TITLE
Run Zizmor linting on core actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,37 +51,37 @@ jobs:
           # Test OS values with fixed test-folder and pixi-version
           - os: ubuntu-latest
             test-folder: just-pixi-toml
-            expected-hash: "pixi-lock__69110db0bf39d7ce64fd774c7078ccd56ebf8542d9a1e86f84e63011634dc43f_2026-02-24"
+            expected-hash: "pixi-lock__69110db0bf39d7ce64fd774c7078ccd56ebf8542d9a1e86f84e63011634dc43f_{TODAYS_DATE}"
             pixi-version: ""
           - os: macos-latest
             test-folder: just-pixi-toml
-            expected-hash: "pixi-lock__69110db0bf39d7ce64fd774c7078ccd56ebf8542d9a1e86f84e63011634dc43f_2026-02-24"
+            expected-hash: "pixi-lock__69110db0bf39d7ce64fd774c7078ccd56ebf8542d9a1e86f84e63011634dc43f_{TODAYS_DATE}"
             pixi-version: ""
           - os: windows-latest
             test-folder: just-pixi-toml
-            expected-hash: "pixi-lock__adbacdefe20c62f204989acf366ef09911f3af89f066088613341b946be131e8_2026-02-24"
+            expected-hash: "pixi-lock__adbacdefe20c62f204989acf366ef09911f3af89f066088613341b946be131e8_{TODAYS_DATE}"
             pixi-version: ""
           # Test test-folder values with fixed OS and pixi-version
           - os: ubuntu-latest
             test-folder: just-pixi-toml
-            expected-hash: "pixi-lock__69110db0bf39d7ce64fd774c7078ccd56ebf8542d9a1e86f84e63011634dc43f_2026-02-24"
+            expected-hash: "pixi-lock__69110db0bf39d7ce64fd774c7078ccd56ebf8542d9a1e86f84e63011634dc43f_{TODAYS_DATE}"
             pixi-version: ""
           - os: ubuntu-latest
             test-folder: just-pyproject-toml
-            expected-hash: "pixi-lock__4a057faded2062ff018955c0be1db1b9e1d2fb8d1fe4303d8b778af7fd9e411d_2026-02-24"
+            expected-hash: "pixi-lock__4a057faded2062ff018955c0be1db1b9e1d2fb8d1fe4303d8b778af7fd9e411d_{TODAYS_DATE}"
             pixi-version: ""
           - os: ubuntu-latest
             test-folder: pyproject-and-pixi-toml
-            expected-hash: "pixi-lock__b5bae43771086cb1dd79c43dc06881f8b0e006ad8c54e7269dad1a4f8ce96522_2026-02-24"
+            expected-hash: "pixi-lock__b5bae43771086cb1dd79c43dc06881f8b0e006ad8c54e7269dad1a4f8ce96522_{TODAYS_DATE}"
             pixi-version: ""
           # Test pixi-version values with fixed OS and test-folder
           - os: ubuntu-latest
             test-folder: just-pixi-toml
-            expected-hash: "pixi-lock__69110db0bf39d7ce64fd774c7078ccd56ebf8542d9a1e86f84e63011634dc43f_2026-02-24"
+            expected-hash: "pixi-lock__69110db0bf39d7ce64fd774c7078ccd56ebf8542d9a1e86f84e63011634dc43f_{TODAYS_DATE}"
             pixi-version: ""
           - os: ubuntu-latest
             test-folder: just-pixi-toml
-            expected-hash: "pixi-lock_v0.63.2_69110db0bf39d7ce64fd774c7078ccd56ebf8542d9a1e86f84e63011634dc43f_2026-02-24"
+            expected-hash: "pixi-lock_v0.63.2_69110db0bf39d7ce64fd774c7078ccd56ebf8542d9a1e86f84e63011634dc43f_{TODAYS_DATE}"
             pixi-version: "v0.63.2"
     steps:
       - name: Checkout repository
@@ -104,6 +104,7 @@ jobs:
         run: |
           actual_hash="${{ steps.create-and-cache.outputs.cache-key }}"
           expected_hash="${{ matrix.expected-hash }}"
+          expected_hash="${expected_hash/\{TODAYS_DATE\}/$(date +%Y-%m-%d)}"
           echo "Expected hash: $expected_hash"
           echo "Actual hash: $actual_hash"
           if [ "$actual_hash" != "$expected_hash" ]; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,10 @@ repos:
       - id: check-json
         types: [text]
         files: \.(json|ipynb)$
+  # - repo: https://github.com/zizmorcore/zizmor-pre-commit
+  #   rev: v1.23.1
+  #   hooks:
+  #     - id: zizmor
   - repo: https://github.com/rbubley/mirrors-prettier # Update mirror as official mirror is deprecated
     rev: v3.6.2
     hooks:

--- a/create-and-cache/action.yml
+++ b/create-and-cache/action.yml
@@ -27,9 +27,12 @@ runs:
     - name: Get cache key
       id: cache-key
       shell: bash
+      env:
+        PIXI_VERSION: ${{ inputs.pixi-version }}
+        HASH_FILES: ${{ hashFiles(inputs.hash-files) }}
       run: |
         today=$(date +'%Y-%m-%d')
-        key="pixi-lock_${{ inputs.pixi-version }}_${{ hashFiles(inputs.hash-files) }}_${today}"
+        key="pixi-lock_${PIXI_VERSION}_${HASH_FILES}_${today}"
         echo "key=${key}" >> "$GITHUB_OUTPUT"
 
     - name: Restore pixi.lock from cache

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -11,8 +11,10 @@ runs:
   steps:
     - name: Check cache-key
       shell: bash
+      env:
+        CACHE_KEY: ${{ inputs.cache-key }}
       run: |
-        if [[ -z "${{ inputs.cache-key }}" ]]; then
+        if [[ -z "${CACHE_KEY}" ]]; then
           echo "::error::cache-key cannot be an empty string"
           exit 1
         fi
@@ -20,8 +22,10 @@ runs:
     - name: Calculate fallback key
       id: fallback
       shell: bash
+      env:
+        CACHE_KEY: ${{ inputs.cache-key }}
       run: |
-        cache_key="${{ inputs.cache-key }}"
+        cache_key="${CACHE_KEY}"
         # Extract base (everything before the last _) and date (after the last _)
         base="${cache_key%_*}"
         current_date="${cache_key##*_}"


### PR DESCRIPTION
This PR runs and fixes linting (pedantic mode) on the core actions which are used in other projects.

This PR does not enable the pre-commit hook as this would run for the whole project (and the tests haven't been updated wrt. zizmor linting)